### PR TITLE
Allow specifying JVM classpath by environment

### DIFF
--- a/jq.c
+++ b/jq.c
@@ -316,15 +316,11 @@ jdbc_jvm_init(const ForeignServer * server, const UserMapping * user)
 	if (FunctionCallCheck == false)
 	{
 		const char* env_classpath = getenv("CLASSPATH");
-		int classpath_length = strlen(strpkglibdir) + 19;
 
 		if (env_classpath != NULL) {
-			classpath_length += 1 + strlen(env_classpath);
-			classpath = (char *) palloc0(classpath_length);
-			snprintf(classpath, classpath_length, "-Djava.class.path=%s" PATH_SEPARATOR "%s", strpkglibdir, env_classpath);
+			classpath = psprintf("-Djava.class.path=%s" PATH_SEPARATOR "%s", strpkglibdir, env_classpath);
 		} else {
-			classpath = (char *) palloc0(classpath_length);
-			snprintf(classpath, classpath_length, "-Djava.class.path=%s", strpkglibdir);
+			classpath = psprintf("-Djava.class.path=%s", strpkglibdir);
 		}
 
 


### PR DESCRIPTION
There are use cases where specification of multiple directories to search for JVM libraries are helpful. In our case, we are installing a large client driver package to our image and need to add multiple directories to the classpath in order for the JDBC driver to pick up its dependencies.

This adds an option to define an environment variable `CLASSPATH` according to the [JVM documentation](https://docs.oracle.com/javase/tutorial/essential/environment/paths.html) and pass its value as VM arguments.